### PR TITLE
12 feature request file independant

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41
         with:
           python-version: ${{ matrix.python-version }}
       - name: UV Build

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyberark-tpc-plugin-parser"
-version = "0.2.0"
+version = "0.3.0"
 description = "A package to help parse CyberArk TPC plugin prompts and process files."
 keywords = ["cyberark", "parser", "tpc"]
 authors = [{ name = "Peter McDonald", email = "git@petermcdonald.co.uk"}]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -32,7 +32,6 @@ class TestParser(object):
         assert len(parser.parsed_file["parameters"]) == 5
         assert len(parser.parsed_file["Debug Information"]) == 7
 
-
     @pytest.mark.parametrize(
         "target_file",
         [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,37 +8,48 @@ class TestParser(object):
     """Test the lexer."""
 
     @pytest.mark.parametrize(
-        "process_file,prompts_file",
+        "target_file",
         [
-            (
-                "tests/data/process.ini",
-                "tests/data/prompts.ini",
-            ),
+            "tests/data/process.ini",
         ],
     )
-    def test_parser(self, process_file: str, prompts_file: str) -> None:
+    def test_process(self, target_file: str) -> None:
         """
-        Test to ensure that a token parses ok.
+        Test to ensure that process file tokens parses ok.
 
-        :param process_file: Path to the process file.
-        :param prompts_file: Path to the prompts file.
+        :param target_file: Path to the file.
         """
-        with open(process_file, "r") as process_file:
-            process_content = process_file.read()
+        with open(target_file, "r") as file_handler:
+            file_content = file_handler.read()
 
-        with open(prompts_file, "r") as prompts_file:
-            prompts_content = prompts_file.read()
+        parser = Parser(file_contents=file_content)
 
-        parser = Parser(process_file=process_content, prompts_file=prompts_content)
+        assert len(parser.parsed_file) == 6
+        assert len(parser.parsed_file["default"]) == 6
+        assert len(parser.parsed_file["states"]) == 8
+        assert len(parser.parsed_file["transitions"]) == 7
+        assert len(parser.parsed_file["CPM Parameters Validation"]) == 5
+        assert len(parser.parsed_file["parameters"]) == 5
+        assert len(parser.parsed_file["Debug Information"]) == 7
 
-        assert len(parser.process_file) == 6
-        assert len(parser.process_file["default"]) == 6
-        assert len(parser.process_file["states"]) == 8
-        assert len(parser.process_file["transitions"]) == 7
-        assert len(parser.process_file["CPM Parameters Validation"]) == 5
-        assert len(parser.process_file["parameters"]) == 5
-        assert len(parser.process_file["Debug Information"]) == 7
 
-        assert len(parser.prompts_file) == 2
-        assert len(parser.prompts_file["default"]) == 6
-        assert len(parser.prompts_file["conditions"]) == 8
+    @pytest.mark.parametrize(
+        "target_file",
+        [
+            "tests/data/prompts.ini",
+        ],
+    )
+    def test_prompts(self, target_file: str) -> None:
+        """
+        Test to ensure that prompts file tokens parses ok.
+
+        :param target_file: Path to the file.
+        """
+        with open(target_file, "r") as file_handler:
+            file_content = file_handler.read()
+
+        parser = Parser(file_contents=file_content)
+
+        assert len(parser.parsed_file) == 2
+        assert len(parser.parsed_file["default"]) == 6
+        assert len(parser.parsed_file["conditions"]) == 8

--- a/tpc_plugin_parser/parser.py
+++ b/tpc_plugin_parser/parser.py
@@ -1,4 +1,4 @@
-"""Parser module for reading and processing configuration files."""
+"""Parser module for reading and processing TPC files."""
 
 from tpc_plugin_parser.lexer.lexer import Lexer
 from tpc_plugin_parser.lexer.tokens.section_header import SectionHeader
@@ -10,23 +10,18 @@ class Parser(object):
     """Object to handle parsing ini files."""
 
     __slots__ = (
-        "_process_file",
-        "_prompts_file",
+        "_file",
     )
 
-    def __init__(self, process_file: str, prompts_file: str) -> None:
+    def __init__(self, file_contents: str) -> None:
         """
-        Initializes the Parser with the given process and prompts files.
+        Initializes the Parser with the given file contents.
 
-        :param process_file (str): Content of the process file.
-        :param prompts_file (str): Content of the prompts file.
+        :param file_contents (str): Content of the file to be parsed.
         """
 
-        process_lexer = Lexer(source=process_file)
+        process_lexer = Lexer(source=file_contents)
         self._prepare_process(lexed_process=process_lexer)
-
-        prompts_lexer = Lexer(source=prompts_file)
-        self._prepare_prompts(lexed_prompts=prompts_lexer)
 
     def _prepare_process(self, lexed_process: Lexer) -> None:
         """
@@ -34,15 +29,7 @@ class Parser(object):
 
         :param lexed_process: Result of lexing the process file.
         """
-        self._process_file = self._process_lex(lexed_file=lexed_process)
-
-    def _prepare_prompts(self, lexed_prompts: Lexer) -> None:
-        """
-        Prepare the prompts file from the lexed result.
-
-        :param lexed_prompts: Result of lexing the prompts file.
-        """
-        self._prompts_file = self._process_lex(lexed_file=lexed_prompts)
+        self._file = self._process_lex(lexed_file=lexed_process)
 
     @staticmethod
     def _process_lex(lexed_file: Lexer):
@@ -71,19 +58,10 @@ class Parser(object):
         return sorted_lex
 
     @property
-    def process_file(self):
+    def parsed_file(self):
         """
-        Returns the parsed process configuration.
+        Returns the parsed file.
 
-        :return: List of tokens from the process file.
+        :return: List of tokens from the file.
         """
-        return self._process_file
-
-    @property
-    def prompts_file(self):
-        """
-        Returns the parsed prompts file.
-
-        :return: List of tokens from the prompts file.
-        """
-        return self._prompts_file
+        return self._file

--- a/tpc_plugin_parser/parser.py
+++ b/tpc_plugin_parser/parser.py
@@ -9,9 +9,7 @@ from tpc_plugin_parser.lexer.utilities.types import ALL_TOKEN_TYPES
 class Parser(object):
     """Object to handle parsing ini files."""
 
-    __slots__ = (
-        "_file",
-    )
+    __slots__ = ("_file",)
 
     def __init__(self, file_contents: str) -> None:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -117,7 +117,7 @@ toml = [
 
 [[package]]
 name = "cyberark-tpc-plugin-parser"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Updated the code so that the parser is not aware of the file that it is parsing, thus allowing validation of single files.

## Summary by Sourcery

Make the parser file-agnostic by consolidating its API to accept single file contents and expose a unified parsed_file property; update tests accordingly to validate individual file parsing; bump package version; and update UV setup action references in CI workflows.

Enhancements:
- Simplify Parser to take a single file_contents input and unify parsing under parsed_file property
- Remove separate process_file and prompts_file slots and properties

Build:
- Bump project version from 0.2.0 to 0.3.0 in pyproject.toml

CI:
- Update astral-sh/setup-uv action references in publish.yml and uv.yml

Tests:
- Refactor tests to parameterize on a single target_file and validate parsing of process and prompts files independently