### PR TITLE
Added typing to parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyberark-tpc-plugin-parser"
-version = "0.3.0"
+version = "0.3.1"
 description = "A package to help parse CyberArk TPC plugin prompts and process files."
 keywords = ["cyberark", "parser", "tpc"]
 authors = [{ name = "Peter McDonald", email = "git@petermcdonald.co.uk"}]

--- a/tpc_plugin_parser/lexer/lexer.py
+++ b/tpc_plugin_parser/lexer/lexer.py
@@ -99,9 +99,9 @@ class Lexer(object):
 
         :param match: Regex match of the assignment.
         """
-        name: str = str(match["name"]).strip()
-        equals = str(match["equals"]).strip() if match.groupdict().get("equals", None) else None
-        assigned_stripped = str(match["value"]).strip() if match.groupdict().get("value", None) else None
+        name: str = str(match.group("name")).strip()
+        equals = str(match.group("equals")).strip() if match.groupdict().get("equals", None) else None
+        assigned_stripped = str(match.group("value")).strip() if match.groupdict().get("value", None) else None
         assigned = assigned_stripped or None
         self._tokens.append(
             (
@@ -135,16 +135,16 @@ class Lexer(object):
         :param match: Regex match of the parameter validation.
         """
         allow_characters: str | None = None
-        if match["allowcharacters"]:
-            allow_characters = str(match["allowcharacters"]).strip()
+        if match.group("allowcharacters"):
+            allow_characters = str(match.group("allowcharacters")).strip()
 
         self._tokens.append(
             (
                 TokenName.CPM_PARAMETER_VALIDATION,
                 CPMParameterValidation(
-                    name=str(match["name"]),
-                    source=str(match["source"]),
-                    mandatory=str(match["mandatory"]),
+                    name=str(match.group("name")),
+                    source=str(match.group("source")),
+                    mandatory=str(match.group("mandatory")),
                     allow_characters=allow_characters,
                     line_number=line_number,
                 ),
@@ -161,9 +161,9 @@ class Lexer(object):
             (
                 TokenName.FAIL_STATE,
                 FailState(
-                    name=str(match["name"]).strip(),
-                    message=str(match["message"]).strip(),
-                    code=int(match["code"]),
+                    name=str(match.group("name")).strip(),
+                    message=str(match.group("message")).strip(),
+                    code=int(match.group("code")),
                     line_number=line_number,
                 ),
             )
@@ -195,7 +195,10 @@ class Lexer(object):
         self._tokens.append(
             (
                 TokenName.SECTION_HEADER,
-                SectionHeader(name=str(match["name"].strip()), line_number=line_number),
+                SectionHeader(
+                    name=str(match.group("name").strip()),
+                    line_number=line_number,
+                ),
             )
         )
 
@@ -209,9 +212,9 @@ class Lexer(object):
             (
                 TokenName.TRANSITION,
                 Transition(
-                    current_state=str(match["current"]).strip(),
-                    condition=str(match["condition"]).strip(),
-                    next_state=str(match["next"]).strip(),
+                    current_state=str(match.group("current")).strip(),
+                    condition=str(match.group("condition")).strip(),
+                    next_state=str(match.group("next")).strip(),
                     line_number=line_number,
                 ),
             )

--- a/tpc_plugin_parser/lexer/lexer.py
+++ b/tpc_plugin_parser/lexer/lexer.py
@@ -99,9 +99,9 @@ class Lexer(object):
 
         :param match: Regex match of the assignment.
         """
-        name: str = str(match.group("name")).strip()
-        equals = str(match.group("equals")).strip() if match.groupdict().get("equals", None) else None
-        assigned_stripped = str(match.group("value")).strip() if match.groupdict().get("value", None) else None
+        name: str = str(match["name"]).strip()
+        equals = str(match["equals"]).strip() if match.groupdict().get("equals", None) else None
+        assigned_stripped = str(match["value"]).strip() if match.groupdict().get("value", None) else None
         assigned = assigned_stripped or None
         self._tokens.append(
             (
@@ -124,10 +124,7 @@ class Lexer(object):
         self._tokens.append(
             (
                 TokenName.COMMENT,
-                Comment(
-                    content=str(match.group("comment")).strip(),
-                    line_number=line_number,
-                ),
+                Comment(content=str(match["comment"]).strip(), line_number=line_number),
             )
         )
 
@@ -138,16 +135,16 @@ class Lexer(object):
         :param match: Regex match of the parameter validation.
         """
         allow_characters: str | None = None
-        if match.group("allowcharacters"):
-            allow_characters = str(match.group("allowcharacters")).strip()
+        if match["allowcharacters"]:
+            allow_characters = str(match["allowcharacters"]).strip()
 
         self._tokens.append(
             (
                 TokenName.CPM_PARAMETER_VALIDATION,
                 CPMParameterValidation(
-                    name=str(match.group("name")),
-                    source=str(match.group("source")),
-                    mandatory=str(match.group("mandatory")),
+                    name=str(match["name"]),
+                    source=str(match["source"]),
+                    mandatory=str(match["mandatory"]),
                     allow_characters=allow_characters,
                     line_number=line_number,
                 ),
@@ -164,9 +161,9 @@ class Lexer(object):
             (
                 TokenName.FAIL_STATE,
                 FailState(
-                    name=str(match.group("name")).strip(),
-                    message=str(match.group("message")).strip(),
-                    code=int(match.group("code")),
+                    name=str(match["name"]).strip(),
+                    message=str(match["message"]).strip(),
+                    code=int(match["code"]),
                     line_number=line_number,
                 ),
             )
@@ -198,10 +195,7 @@ class Lexer(object):
         self._tokens.append(
             (
                 TokenName.SECTION_HEADER,
-                SectionHeader(
-                    name=str(match.group("name").strip()),
-                    line_number=line_number,
-                ),
+                SectionHeader(name=str(match["name"].strip()), line_number=line_number),
             )
         )
 
@@ -215,9 +209,9 @@ class Lexer(object):
             (
                 TokenName.TRANSITION,
                 Transition(
-                    current_state=str(match.group("current")).strip(),
-                    condition=str(match.group("condition")).strip(),
-                    next_state=str(match.group("next")).strip(),
+                    current_state=str(match["current"]).strip(),
+                    condition=str(match["condition"]).strip(),
+                    next_state=str(match["next"]).strip(),
                     line_number=line_number,
                 ),
             )

--- a/tpc_plugin_parser/lexer/utilities/regex.py
+++ b/tpc_plugin_parser/lexer/utilities/regex.py
@@ -4,8 +4,15 @@ ASSIGNMENT: str = (
     r"^(?:[\s]*)(?P<name>[\w]+)(?:(?:[\s]*)(?P<equals>=)(?:(?:[\s]*)(?P<value>(?:(?!\s*fail\s*\().)+))?)?(?:[\s]*)$"
 )
 COMMENT: str = r"^(?:[\s]*)(?P<comment>(?:[#;]+)(?:.*))(?:[\s]*)$"
-CPM_PARAMETER_VALIDATION: str = r"^(?:[\s]*)(?P<name>[\w\\]+)(?:(?:[\s]*,[\s]*)(?:source)(?:[\s]*)=(?:[\s]*)(?P<source>[^, ]*))(?:(?:[\s]*,[\s]*)(?:mandatory)(?:[\s]*)=(?:[\s]*)(?P<mandatory>[^,]*))?(?:(?:[\s]*,[\s]*)(?:allowcharacters)(?:[\s]*)=(?:[\s]*)(?P<allowcharacters>.*))?$"
-FAIL_STATE: str = r"^(?:[\s]*)(?P<name>[\w]+)(?:[\s]*)=(?:[\s]*)(?:[\s]*)(?:fail)(?:[\s]*)\((?:[\s]*)(?P<message>.*)(?:[\s])?,(?:[\s]*)(?P<code>[0-9]+)\)(?:[\s]*)$"
+CPM_PARAMETER_VALIDATION: str = (
+    r"^(?:[\s]*)(?P<name>[\w\\]+)(?:(?:[\s]*,[\s]*)(?:source)(?:[\s]*)=(?:[\s]*)"
+    r"(?P<source>[^, ]*))(?:(?:[\s]*,[\s]*)(?:mandatory)(?:[\s]*)=(?:[\s]*)"
+    r"(?P<mandatory>[^,]*))?(?:(?:[\s]*,[\s]*)(?:allowcharacters)(?:[\s]*)=(?:[\s]*)(?P<allowcharacters>.*))?$"
+)
+FAIL_STATE: str = (
+    r"^(?:[\s]*)(?P<name>[\w]+)(?:[\s]*)=(?:[\s]*)(?:[\s]*)(?:fail)(?:[\s]*)\((?:[\s]*)"
+    r"(?P<message>.*)(?:[\s])?,(?:[\s]*)(?P<code>[0-9]+)\)(?:[\s]*)$"
+)
 SECTION_HEADER: str = r"^(?:[\s]*)\[(?P<name>[\w]+(?:[\s]+[\w]+)*)](?:[\s]*)$"
 TRANSITION: str = (
     r"^(?:[\s]*)(?P<current>[\w]+)(?:[\s]*,[\s]*)(?P<condition>[\w]+)(?:[\s]*,[\s]*)(?P<next>[\w]+)(?:[\s]*)$"

--- a/tpc_plugin_parser/lexer/utilities/regex.py
+++ b/tpc_plugin_parser/lexer/utilities/regex.py
@@ -1,10 +1,12 @@
 """List of regex the lexer uses."""
 
-ASSIGNMENT = (
+ASSIGNMENT: str = (
     r"^(?:[\s]*)(?P<name>[\w]+)(?:(?:[\s]*)(?P<equals>=)(?:(?:[\s]*)(?P<value>(?:(?!\s*fail\s*\().)+))?)?(?:[\s]*)$"
 )
-COMMENT = r"^(?:[\s]*)(?P<comment>(?:[#;]+)(?:.*))(?:[\s]*)$"
-CPM_PARAMETER_VALIDATION = r"^(?:[\s]*)(?P<name>[\w\\]+)(?:(?:[\s]*,[\s]*)(?:source)(?:[\s]*)=(?:[\s]*)(?P<source>[^, ]*))(?:(?:[\s]*,[\s]*)(?:mandatory)(?:[\s]*)=(?:[\s]*)(?P<mandatory>[^,]*))?(?:(?:[\s]*,[\s]*)(?:allowcharacters)(?:[\s]*)=(?:[\s]*)(?P<allowcharacters>.*))?$"
-FAIL_STATE = r"^(?:[\s]*)(?P<name>[\w]+)(?:[\s]*)=(?:[\s]*)(?:[\s]*)(?:fail)(?:[\s]*)\((?:[\s]*)(?P<message>.*)(?:[\s])?,(?:[\s]*)(?P<code>[0-9]+)\)(?:[\s]*)$"
-SECTION_HEADER = r"^(?:[\s]*)\[(?P<name>[\w]+(?:[\s]+[\w]+)*)](?:[\s]*)$"
-TRANSITION = r"^(?:[\s]*)(?P<current>[\w]+)(?:[\s]*,[\s]*)(?P<condition>[\w]+)(?:[\s]*,[\s]*)(?P<next>[\w]+)(?:[\s]*)$"
+COMMENT: str = r"^(?:[\s]*)(?P<comment>(?:[#;]+)(?:.*))(?:[\s]*)$"
+CPM_PARAMETER_VALIDATION: str = r"^(?:[\s]*)(?P<name>[\w\\]+)(?:(?:[\s]*,[\s]*)(?:source)(?:[\s]*)=(?:[\s]*)(?P<source>[^, ]*))(?:(?:[\s]*,[\s]*)(?:mandatory)(?:[\s]*)=(?:[\s]*)(?P<mandatory>[^,]*))?(?:(?:[\s]*,[\s]*)(?:allowcharacters)(?:[\s]*)=(?:[\s]*)(?P<allowcharacters>.*))?$"
+FAIL_STATE: str = r"^(?:[\s]*)(?P<name>[\w]+)(?:[\s]*)=(?:[\s]*)(?:[\s]*)(?:fail)(?:[\s]*)\((?:[\s]*)(?P<message>.*)(?:[\s])?,(?:[\s]*)(?P<code>[0-9]+)\)(?:[\s]*)$"
+SECTION_HEADER: str = r"^(?:[\s]*)\[(?P<name>[\w]+(?:[\s]+[\w]+)*)](?:[\s]*)$"
+TRANSITION: str = (
+    r"^(?:[\s]*)(?P<current>[\w]+)(?:[\s]*,[\s]*)(?P<condition>[\w]+)(?:[\s]*,[\s]*)(?P<next>[\w]+)(?:[\s]*)$"
+)

--- a/tpc_plugin_parser/parser.py
+++ b/tpc_plugin_parser/parser.py
@@ -30,7 +30,7 @@ class Parser(object):
         self._file = self._process_lex(lexed_file=lexed_process)
 
     @staticmethod
-    def _process_lex(lexed_file: Lexer):
+    def _process_lex(lexed_file: Lexer) -> dict[str, list[ALL_TOKEN_TYPES]]:
         """
         Process a lex and return the results.
 
@@ -56,7 +56,7 @@ class Parser(object):
         return sorted_lex
 
     @property
-    def parsed_file(self):
+    def parsed_file(self) -> dict[str, list[ALL_TOKEN_TYPES]]:
         """
         Returns the parsed file.
 

--- a/uv.lock
+++ b/uv.lock
@@ -117,7 +117,7 @@ toml = [
 
 [[package]]
 name = "cyberark-tpc-plugin-parser"
-version = "0.3.0"
+version = "0.3.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Added typing to parser.py.
Updated regex matches to use dict notation rather than groups.

Fixes #14

## Summary by Sourcery

Add type hints to parser and lexer functions, annotate regex constants, switch named group access to dict notation, and bump version to 0.3.1.

Enhancements:
- Add type annotations to parser methods and regex constants
- Refactor usage of re.Match to use dict-style named group access
- Reformat regex patterns as typed string constants across utilities

Chores:
- Bump package version to 0.3.1